### PR TITLE
Correct + Clarify some update-cart address info

### DIFF
--- a/en/update-cart-addresses.md
+++ b/en/update-cart-addresses.md
@@ -4,13 +4,13 @@ You may wish for the customer to supply a shipping and billing address for the o
 
 You can see if the cart has a billing and shipping address has been set with:
 
-```
+```twig
 {% if cart.shippingAddress %}
 	{{ cart.shippingAddress.firstName }} ...etc
 {% endif %}
 ```
 and
-```
+```twig
 {% if cart.billingAddress %}
   {{ cart.billingAddress.firstName }} ... etc
 {% endif %}
@@ -21,29 +21,31 @@ Both cart attributes return an [Address Model](address-model.md), or `null` if n
 
 ## Adding or updating the shipping and billing address selected for the current cart.
 
-Adding or updating the addresses on the order is done using the `commerce/cart/updateCart` form action.
+Adding or updating the addresses on the order is done using the `commerce/cart/update-cart` form action.
 
 There are a number of ways you can do this:
 
-### 1. Using an existing Address ID
+### 1. Using an existing Address ID as the default
 
-The first example below shows adding the first address owned by the customer as the `shippingAddressId` and also setting it as the `billingAddressId` by using the param `sameAddress`:
+The example below shows how you can add the first address owned by the customer as the `shippingAddressId` while also setting it as the order's billing address, by using the `billingAddressSameAsShipping` param:
 
-```
+```twig
 {% set address = craft.commerce.customer.addresses|first %}
 
 <form method="POST">
     <input type="hidden" name="action" value="commerce/cart/updateCart">
     <input type="hidden" name="redirect" value="commerce/cart">
     <input type="hidden" name="shippingAddressId" value="{{ address.id }}">
-    <input type="hidden" name="sameAddress" value="1">
+    <input type="hidden" name="billingAddressSameAsShipping" value="1">
     <input type="submit" value="Submit">
 </form>
 ```
 
+The inverse is possible as well, providing the `billingAddressId` and setting the `shippingAddressSameAsBilling` param.
+
 Another way of achieving the same thing is is setting both addresses explicitly:
 
-```
+```twig
 {% set address = craft.commerce.customer.addresses|first %}
 
 <form method="POST">
@@ -62,7 +64,7 @@ Another alternative, if the user wanted to submit new addresses, (they may be a 
 This will only work if the shippingAddressId is not supplied or is set to a non ID like the word 'new'.
 If `shippingAddressId` is an integer then the address form data is ignored and the form action attempts to set the shipping address to that of the ID.
 
-```
+```twig
 <form method="POST">
     <input type="hidden" name="action" value="commerce/cart/updateCart">
     <input type="hidden" name="redirect" value="commerce/cart">
@@ -79,7 +81,61 @@ If `shippingAddressId` is an integer then the address form data is ignored and t
 </form>
 ```
 
+### 3. Select from existing addresses
+
+If your customers have added multiple addresses, you can use radio buttons to select the proper `shippingAddressId` and `billingAddressId`, or create a new address on-the-fly:
+
+```twig
+{% set cart = craft.commerce.carts.cart %}
+
+<form class="form" method="post">
+    {{ csrfInput() }}
+    <input type="hidden" name="action" value="commerce/cart/update-cart">
+
+    {% set customerAddresses = craft.commerce.customer.addresses %}
+
+    {# Check if we have saved addresses: #}
+    {% if customerAddresses | length %}
+        <div class="shipping-address">
+            {% for address in customerAddresses %}
+                <label>
+                    <input type="radio" name="shippingAddressId" value="{{ address.id }}" {{- cart.shippingAddressId ? ' checked' : null }}>
+                    {# Identifying address information, up to you! #}
+                </label>
+            {% endfor %}
+        </div>
+
+        <div class="billing-address">
+            {% for address in customerAddresses %}
+                <label>
+                    <input type="radio" name="billingAddressId" value="{{ address.id }}" {{- cart.billingAddressId ? ' checked' : null }}>
+                    {# Identifying address information, up to you! #}
+                </label>
+            {% endfor %}
+        </div>
+    {% else %}
+        {# If no existing addresses were found, provide forms to add new ones: #}
+        <div class="new-billing-address">
+            <label>
+                First Name
+                <input type="text" name="billingAddress[firstName]">
+            </label>
+            {# ...remainder of address fields... #}
+        </div>
+
+        <div class="new-shipping-address">
+            <label>
+                First Name
+                <input type="text" name="shippingAddress[firstName]">
+            </label>
+            {# ...remainder of address fields... #}
+        </div>
+    {% endif %}
+</form>
+```
+
+You may need to create other custom routes to allow customers to manage these addresses, or introduce some logic in the browser to hide and show new address forms based on the type(s) of addresses you need.
+
 ## Summary
 
-As you can see from both examples, the shipping address is *always* submitted, and the billingAddress can either be also included, or set to the same address as the shipping address with the `sameAddress` param.
-
+When using the `update-cart` action, you may include both new shipping and billing address (properly nested under their repsective keys, `shippingAddress[...]` and `billingAddress[...]`), or select existing addresses using one or the other of the `shippingAddressId` and `billingAddressId` params. In either example, you can include `shippingAddressSameAsBilling` or `billingAddressSameAsShipping` to synchronize the attached addresses.


### PR DESCRIPTION
Some properties seemed to be carried over from Commerce 1—corrected those, and added some extra notes about picking from existing addresses.