### PR TITLE
Corrected variant hasSales example

### DIFF
--- a/en/craft-variants.md
+++ b/en/craft-variants.md
@@ -50,7 +50,7 @@ Accepts: `true` or `false`
 For example:
 
 ```twig
-{% set products = craft.products({
+{% set products = craft.products.hasVariant({
   hasSales: true
 }) %}
 ```


### PR DESCRIPTION
Hello,

I'm not sure if this is something in my project or the documentation is wrong, but using the existing documentation I was getting an Unknown Property error, but using the following.

``` 
{% set products = craft.products.hasVariant({
  hasSales: true
}) %}
```

Worked fine, hopefully this can help save someone some head scratching.

Simon